### PR TITLE
Extended information string in case no binary provided

### DIFF
--- a/addons/io_scene_gltf2/io/com/gltf2_io_draco_compression_extension.py
+++ b/addons/io_scene_gltf2/io/com/gltf2_io_draco_compression_extension.py
@@ -60,5 +60,9 @@ def dll_exists(quiet=False) -> bool:
     exists = dll_path().exists()
     if quiet is False:
         print("'{}' ".format(dll_path().absolute()) + ("exists, draco mesh compression is available" if exists else
-                                                       "does not exist, draco mesh compression not available"))
+                                                       "{} {} {}".format(
+                                                           "does not exist, draco mesh compression not available,",
+                                                           "please add it or create environment variable BLENDER_EXTERN_DRACO_LIBRARY_PATH",
+                                                           "pointing to the folder"
+                                                      )))
     return exists


### PR DESCRIPTION
In case binary file is not included in Blender3D installation it would be nice for user to know the fastest way to solve the problem without visiting source files.

My case is that Blender3D uses OS Python libraries and adding ```blender_root / python_lib / python_version / 'site_packages'``` folder to my installation breaks Python or some of it's dependencies. Adding BLENDER_EXTERN_DRACO_LIBRARY_PATH with binary file is the fastest way to solve a problem.